### PR TITLE
[WIP] Add circuit benchmark scripts

### DIFF
--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -38,6 +38,7 @@ class BaseCircuit(ABC):
     def __init__(self, nqubits, params=None):
         self.nqubits = nqubits
 
+    @staticmethod
     def parse(params):
         p = {}
         if params is not None:
@@ -78,9 +79,9 @@ class TwoQubitGate(BaseCircuit):
     def __iter__(self):
         for _ in range(self.nlayers):
             for i in range(0, self.nqubits - 1, 2):
-                yield self.gate(i)
+                yield self.gate(i, i + 1)
             for i in range(1, self.nqubits - 1, 2):
-                yield self.gate(i)
+                yield self.gate(i, i + 1)
 
 
 class QFT(BaseCircuit):
@@ -106,4 +107,8 @@ class CircuitConstructor:
     def __new__(cls, circuit_name, params, nqubits):
         if circuit_name == "qft":
             return QFT(nqubits, params)
-        raise NotImplementedError
+        elif circuit_name == "one-qubit-gate":
+            return OneQubitGate(nqubits, params)
+        elif circuit_name == "two-qubit-gate":
+            return TwoQubitGate(nqubits, params)
+        raise NotImplementedError(f"Cannot find circuit {circuit_name}.")

--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -1,0 +1,47 @@
+import numpy as np
+from qibo import models, gates
+
+
+def variational_circuit(nqubits, nlayers=1, theta=None, use_varlayer=False):
+    if theta is None:
+        theta = 2 * np.pi * np.random.random(2 * nlayers * nqubits)
+
+    if use_varlayer:
+        theta = theta_values.reshape((2 * nlayers, nqubits))
+        pairs = list((i, i + 1) for i in range(0, nqubits - 1, 2))
+        for l in range(nlayers):
+            yield gates.VariationalLayer(range(nqubits), pairs,
+                                         gates.RY, gates.CZ,
+                                         theta[2 * l], theta[2 * l + 1])
+            for i in range(1, nqubits - 2, 2):
+                yield gates.CZ(i, i + 1)
+            yield gates.CZ(0, nqubits - 1)
+
+    else:
+        theta = iter(theta_values)
+        for l in range(nlayers):
+            for i in range(nqubits):
+                yield gates.RY(i, next(theta))
+            for i in range(0, nqubits - 1, 2):
+                yield gates.CZ(i, i + 1)
+            for i in range(nqubits):
+                yield gates.RY(i, next(theta))
+            for i in range(1, nqubits - 2, 2):
+              yield gates.CZ(i, i + 1)
+            yield gates.CZ(0, nqubits - 1)
+
+
+def one_qubit_gate(nqubits, gate_type="H", params={}, nlayers=1):
+    gate = lambda q: getattr(gates, gate_type)(q, **params)
+    for _ in range(nlayers):
+        for i in range(nqubits):
+            yield gate(i)
+
+
+def two_qubit_gate(nqubits, gate_type="CNOT", params={}, nlayers=1):
+    gate = lambda q: getattr(gates, gate_type)(q, q + 1, **params)
+    for _ in range(nlayers):
+        for i in range(0, nqubits - 1, 2):
+            yield gate(i)
+        for i in range(1, nqubits - 1, 2):
+            yield gate(i)

--- a/benchmarks/logger.py
+++ b/benchmarks/logger.py
@@ -1,0 +1,31 @@
+import os
+import time
+import json
+
+
+class JsonLogger(list):
+
+    def __init__(self, filename=None):
+        self.filename = filename
+        if filename is not None:
+            if os.path.isfile(filename):
+                with open(filename, "r") as file:
+                    super().__init__(json.load(file))
+                print("Extending existing logs from {}.".format(filename))
+                return
+            else:
+                print("Creating new logs in {}.".format(filename))
+        super().__init__()
+
+    def __getitem__(self, x):
+        if isinstance(x, str):
+            return self[-1].get(x)
+        return super().__getitem__(x)
+
+    def __str__(self):
+        return "\n".join(f"{k}: {v}" for k, v in self[-1].items())
+
+    def dump(self):
+        if self.filename is not None:
+            with open(self.filename, "w") as file:
+                json.dump(self, file)

--- a/benchmarks/main.py
+++ b/benchmarks/main.py
@@ -1,0 +1,212 @@
+"""
+Generic benchmark script that runs circuits defined in `benchmark_models.py`.
+
+The type of the circuit is selected using the ``--type`` flag.
+"""
+import argparse
+import os
+import time
+import json
+import numpy as np
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3" # disable Tensorflow warnings
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--nqubits", default=20, type=int)
+parser.add_argument("--type", default="qft", type=str)
+parser.add_argument("--backend", default="qibojit", type=str)
+parser.add_argument("--precision", default="double", type=str)
+parser.add_argument("--nreps", default=1, type=int)
+parser.add_argument("--nshots", default=None, type=int)
+
+parser.add_argument("--device", default=None, type=str)
+parser.add_argument("--accelerators", default=None, type=str)
+parser.add_argument("--memory", default=None, type=int)
+parser.add_argument("--threading", default=None, type=str)
+
+parser.add_argument("--transfer", action="store_true")
+parser.add_argument("--fuse", action="store_true")
+parser.add_argument("--compile", action="store_true")
+parser.add_argument("--nlayers", default=None, type=int)
+parser.add_argument("--gate-type", default=None, type=str)
+
+parser.add_argument("--filename", default=None, type=str)
+
+# params
+_PARAM_NAMES = {"theta", "phi"}
+parser.add_argument("--theta", default=None, type=float)
+parser.add_argument("--phi", default=None, type=float)
+args = vars(parser.parse_args())
+
+
+threading = args.pop("threading")
+if args.get("backend") == "qibojit" and threading is not None:
+    select_numba_threading(threading)
+
+memory = args.pop("memory")
+if args.get("backend") in {"qibotf", "tensorflow"}:
+    limit_gpu_memory(memory)
+
+import qibo
+import circuits
+
+
+def parse_accelerators(accelerators):
+    """Transforms string that specifies accelerators to dictionary.
+
+    The string that is parsed has the following format:
+        n1device1,n2device2,n3device3,...
+    and is transformed to the dictionary:
+        {'device1': n1, 'device2': n2, 'device3': n3, ...}
+
+    Example:
+        2/GPU:0,2/GPU:1 --> {'/GPU:0': 2, '/GPU:1': 2}
+    """
+    if accelerators is None:
+        return None
+
+    def read_digit(x):
+        i = 0
+        while x[i].isdigit():
+            i += 1
+        return x[i:], int(x[:i])
+
+    acc_dict = {}
+    for entry in accelerators.split(","):
+        device, n = read_digit(entry)
+        if device in acc_dict:
+            acc_dict[device] += n
+        else:
+            acc_dict[device] = n
+    return acc_dict
+
+
+def main(nqubits, type,
+         backend="custom", precision="double",
+         device=None, accelerators=None, threadsafe=False,
+         nreps=1, nshots=None,
+         transfer=False, fuse=False, compile=False,
+         nlayers=None, gate_type=None, params={},
+         filename=None):
+    """Runs benchmarks for different circuit types.
+
+    Args:
+        nqubits (int): Number of qubits in the circuit.
+        type (str): Type of Circuit to use.
+            See ``benchmark_models.py`` for available types.
+        device (str): Tensorflow logical device to use for the benchmark.
+            If ``None`` the first available device is used.
+        accelerators (dict): Dictionary that specifies the accelarator devices
+            for multi-GPU setups.
+        nreps (int): Number of repetitions of circuit execution.
+            Dry run is not included. Default is 1.
+        nshots (int): Number of measurement shots.
+            Logs the time required to sample frequencies (no samples).
+            If ``None`` no measurements are performed.
+        transfer (bool): If ``True`` it transfers the array from GPU to CPU.
+            Makes execution and dry run times similar
+            (otherwise execution is much faster).
+        fuse (bool): If ``True`` gate fusion is used for faster circuit execution.
+        compile: If ``True`` then the Tensorflow graph is compiled using
+            ``circuit.compile()``. Compilation time is logged in this case.
+        nlayers (int): Number of layers for supremacy-like or gate circuits.
+            If a different circuit is used ``nlayers`` is ignored.
+        gate_type (str): Type of gate for gate circuits.
+            If a different circuit is used ``gate_type`` is ignored.
+        params (dict): Gate parameter for gate circuits.
+            If a non-parametrized circuit is used then ``params`` is ignored.
+        filename (str): Name of file to write logs.
+            If ``None`` logs will not be saved.
+    """
+    qibo.set_backend(backend)
+    qibo.set_precision(precision)
+    if device is not None:
+        qibo.set_device(device)
+
+    if filename is not None:
+        if os.path.isfile(filename):
+            with open(filename, "r") as file:
+                logs = json.load(file)
+            print("Extending existing logs from {}.".format(filename))
+        else:
+            print("Creating new logs in {}.".format(filename))
+            logs = []
+    else:
+        logs = []
+
+    # Create log dict
+    logs.append({
+        "nqubits": nqubits, "circuit_type": type, "threading": "",
+        "backend": qibo.get_backend(), "precision": qibo.get_precision(),
+        "device": qibo.get_device(), "accelerators": accelerators,
+        "nshots": nshots, "transfer": transfer, "fuse": fuse, "compile": compile
+        })
+
+    params = {k: v for k, v in params.items() if v is not None}
+    kwargs = {"nqubits": nqubits, "circuit_type": type}
+    if params: kwargs["params"] = params
+    if nlayers is not None: kwargs["nlayers"] = nlayers
+    if gate_type is not None: kwargs["gate_type"] = gate_type
+    if accelerators is not None:
+        kwargs["accelerators"] = accelerators
+        kwargs["device"] = device
+    logs[-1].update(kwargs)
+
+    start_time = time.time()
+    circuit = circuits.CircuitFactory(**kwargs)
+    if nshots is not None:
+        # add measurement gates
+        circuit.add(qibo.gates.M(*range(nqubits)))
+    if fuse:
+        circuit = circuit.fuse()
+    logs[-1]["creation_time"] = time.time() - start_time
+
+    if compile:
+        start_time = time.time()
+        circuit.compile()
+        # Try executing here so that compile time is not included
+        # in the simulation time
+        result = circuit(nshots=nshots)
+        logs[-1]["compile_time"] = time.time() - start_time
+
+    start_time = time.time()
+    result = circuit(nshots=nshots)
+    if transfer:
+        result = result.numpy()
+    logs[-1]["dry_run_time"] = time.time() - start_time
+
+    simulation_time = []
+    for _ in range(nreps):
+        start_time = time.time()
+        result = circuit(nshots=nshots)
+        if transfer:
+            result = result.numpy()
+        simulation_time.append(time.time() - start_time)
+    logs[-1]["dtype"] = str(result.dtype)
+    logs[-1]["simulation_time"] = np.mean(simulation_time)
+    logs[-1]["simulation_time_std"] = np.std(simulation_time)
+
+
+    if nshots is not None:
+        start_time = time.time()
+        freqs = result.frequencies()
+        logs[-1]["measurement_time"] = time.time() - start_time
+
+    if logs[-1]["backend"] == "qibojit" and qibo.K.op.get_backend() == "numba":
+        from numba import threading_layer
+        logs[-1]["threading"] = threading_layer()
+
+    print()
+    for k, v in logs[-1].items():
+        print("{}: {}".format(k, v))
+    print()
+
+    if filename is not None:
+        with open(filename, "w") as file:
+            json.dump(logs, file)
+
+
+if __name__ == "__main__":
+    args["accelerators"] = parse_accelerators(args.pop("accelerators"))
+    args["params"] = {k: args.pop(k) for k in _PARAM_NAMES}
+    main(**args)

--- a/benchmarks/main.py
+++ b/benchmarks/main.py
@@ -13,68 +13,51 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3" # disable Tensorflow warnings
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--nqubits", default=20, type=int)
-parser.add_argument("--type", default="qft", type=str)
 parser.add_argument("--backend", default="qibojit", type=str)
 parser.add_argument("--precision", default="double", type=str)
 parser.add_argument("--nreps", default=1, type=int)
+parser.add_argument("--filename", default=None, type=str)
+
+parser.add_argument("--circuit", default="qft", type=str)
+parser.add_argument("--params", default=None, type=str)
 parser.add_argument("--nshots", default=None, type=int)
 
 parser.add_argument("--memory", default=None, type=int)
 parser.add_argument("--threading", default=None, type=str)
-
 parser.add_argument("--transfer", action="store_true")
-parser.add_argument("--nlayers", default=None, type=int)
-parser.add_argument("--gate-type", default=None, type=str)
-
-parser.add_argument("--filename", default=None, type=str)
-
-# params
-_PARAM_NAMES = {"theta", "phi"}
-parser.add_argument("--theta", default=None, type=float)
-parser.add_argument("--phi", default=None, type=float)
-args = vars(parser.parse_args())
 
 
-threading = args.pop("threading")
-if args.get("backend") == "qibojit" and threading is not None:
-    select_numba_threading(threading)
-
-memory = args.pop("memory")
-if args.get("backend") in {"qibotf", "tensorflow"}:
-    limit_gpu_memory(memory)
-
-import qibo
-import circuits
-
-
-def main(nqubits, type, backend="custom", precision="double", threadsafe=False,
-         nreps=1, nshots=None, transfer=False, nlayers=None,
-         gate_type=None, params={}, filename=None):
+def main(nqubits, backend, circuit, precision="double", params=None,
+         nreps=1, nshots=None, memory=None, threading=None,
+         transfer=False, filename=None):
     """Runs benchmarks for different circuit types.
 
     Args:
         nqubits (int): Number of qubits in the circuit.
-        type (str): Type of Circuit to use.
-            See ``benchmark_models.py`` for available types.
+        backend (str): Qibo backend to use for simulation.
+        precision (str): Numerical precision of the simulation.
+            Choose between 'double' and 'single'.
+            Default is 'double'.
+        circuit (str): Type of Circuit to use.
+            See ``circuits.py`` for available types.
         nreps (int): Number of repetitions of circuit execution.
             Dry run is not included. Default is 1.
         nshots (int): Number of measurement shots.
             Logs the time required to sample frequencies (no samples).
             If ``None`` no measurements are performed.
+            Default is ``None``.
         transfer (bool): If ``True`` it transfers the array from GPU to CPU.
-            Makes execution and dry run times similar
-            (otherwise execution is much faster).
-        nlayers (int): Number of layers for supremacy-like or gate circuits.
-            If a different circuit is used ``nlayers`` is ignored.
-        gate_type (str): Type of gate for gate circuits.
-            If a different circuit is used ``gate_type`` is ignored.
-        params (dict): Gate parameter for gate circuits.
-            If a non-parametrized circuit is used then ``params`` is ignored.
         filename (str): Name of file to write logs.
             If ``None`` logs will not be saved.
     """
-    qibo.set_backend(backend)
-    qibo.set_precision(precision)
+    # TODO: Complete docstring
+    if args.get("backend") == "qibojit" and threading is not None:
+        from utils import select_numba_threading
+        threading = select_numba_threading(threading)
+
+    if args.get("backend") in {"qibotf", "tensorflow"} and memory is not None:
+        from utils import limit_gpu_memory
+        memory = limit_gpu_memory(memory)
 
     if filename is not None:
         if os.path.isfile(filename):
@@ -89,60 +72,59 @@ def main(nqubits, type, backend="custom", precision="double", threadsafe=False,
 
     # Create log dict
     logs.append({
-        "nqubits": nqubits, "circuit_type": type, "threading": "",
-        "backend": qibo.get_backend(), "precision": qibo.get_precision(),
-        "nshots": nshots, "transfer": transfer
+        "nqubits": nqubits, "circuit": circuit, "params": params,
+        "nreps": nreps, "nshots": nshots, "transfer": transfer,
+        "numba-threading": threading, "gpu-memory": memory
         })
 
-    params = {k: v for k, v in params.items() if v is not None}
-    kwargs = {"nqubits": nqubits, "circuit_type": type}
-    if params: kwargs["params"] = params
-    if nlayers is not None: kwargs["nlayers"] = nlayers
-    if gate_type is not None: kwargs["gate_type"] = gate_type
-    logs[-1].update(kwargs)
+    start_time = time.time()
+    import qibo
+    logs[-1]["import_time"] = time.time() - start_time
 
+    qibo.set_backend(backend)
+    qibo.set_precision(precision)
+    logs[-1]["backend"] = qibo.get_backend()
+    logs[-1]["precision"] = qibo.get_precision()
+    logs[-1]["device"] = qibo.get_device()
+
+    from circuits import CircuitConstructor
+    gates = CircuitConstructor(circuit, params, nqubits)
     start_time = time.time()
     circuit = qibo.models.Circuit(nqubits)
-    circuit.add()
+    circuit.add(gates)
     if nshots is not None:
         # add measurement gates
         circuit.add(qibo.gates.M(*range(nqubits)))
     logs[-1]["creation_time"] = time.time() - start_time
 
-    if compile:
-        start_time = time.time()
-        circuit.compile()
-        # Try executing here so that compile time is not included
-        # in the simulation time
-        result = circuit(nshots=nshots)
-        logs[-1]["compile_time"] = time.time() - start_time
-
     start_time = time.time()
     result = circuit(nshots=nshots)
+    logs[-1]["dry_run_execution_time"] = time.time() - start_time
+    start_time = time.time()
     if transfer:
         result = result.numpy()
-    logs[-1]["dry_run_time"] = time.time() - start_time
+    logs[-1]["dry_run_transfer_time"] = time.time() - start_time
 
-    simulation_time = []
+    logs[-1]["simulation_times"], logs[-1]["transfer_times"] = [], []
     for _ in range(nreps):
         start_time = time.time()
         result = circuit(nshots=nshots)
+        logs[-1]["simulation_times"].append(time.time() - start_time)
+        start_time = time.time()
         if transfer:
             result = result.numpy()
-        simulation_time.append(time.time() - start_time)
-    logs[-1]["dtype"] = str(result.dtype)
-    logs[-1]["simulation_time"] = np.mean(simulation_time)
-    logs[-1]["simulation_time_std"] = np.std(simulation_time)
+        logs[-1]["transfer_times"].append(time.time() - start_time)
 
+    logs[-1]["dtype"] = str(result.dtype)
+    logs[-1]["simulation_time"] = np.mean(logs[-1]["simulation_times"])
+    logs[-1]["simulation_time_std"] = np.std(logs[-1]["simulation_times"])
+    logs[-1]["transfer_time"] = np.mean(logs[-1]["transfer_times"])
+    logs[-1]["transfer_time_std"] = np.std(logs[-1]["transfer_times"])
 
     if nshots is not None:
         start_time = time.time()
         freqs = result.frequencies()
         logs[-1]["measurement_time"] = time.time() - start_time
-
-    if logs[-1]["backend"] == "qibojit" and qibo.K.op.get_backend() == "numba":
-        from numba import threading_layer
-        logs[-1]["threading"] = threading_layer()
 
     print()
     for k, v in logs[-1].items():
@@ -155,5 +137,5 @@ def main(nqubits, type, backend="custom", precision="double", threadsafe=False,
 
 
 if __name__ == "__main__":
-    args["params"] = {k: args.pop(k) for k in _PARAM_NAMES}
+    args = vars(parser.parse_args())
     main(**args)

--- a/benchmarks/main.py
+++ b/benchmarks/main.py
@@ -6,7 +6,7 @@ The type of the circuit is selected using the ``--type`` flag.
 import argparse
 import os
 import time
-import json
+import logger
 import numpy as np
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3" # disable Tensorflow warnings
 
@@ -59,17 +59,7 @@ def main(nqubits, backend, circuit, precision="double", params=None,
         from utils import limit_gpu_memory
         memory = limit_gpu_memory(memory)
 
-    if filename is not None:
-        if os.path.isfile(filename):
-            with open(filename, "r") as file:
-                logs = json.load(file)
-            print("Extending existing logs from {}.".format(filename))
-        else:
-            print("Creating new logs in {}.".format(filename))
-            logs = []
-    else:
-        logs = []
-
+    logs = logger.JsonLogger(filename)
     # Create log dict
     logs.append({
         "nqubits": nqubits, "circuit": circuit, "params": params,
@@ -127,13 +117,9 @@ def main(nqubits, backend, circuit, precision="double", params=None,
         logs[-1]["measurement_time"] = time.time() - start_time
 
     print()
-    for k, v in logs[-1].items():
-        print("{}: {}".format(k, v))
+    print(logs)
+    logs.dump()
     print()
-
-    if filename is not None:
-        with open(filename, "w") as file:
-            json.dump(logs, file)
 
 
 if __name__ == "__main__":

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -1,0 +1,26 @@
+def limit_gpu_memory(memory_limit=None):
+    """Limits GPU memory that is available to Tensorflow.
+    Args:
+        memory_limit: Memory limit in MBs.
+    """
+    import tensorflow as tf
+    if memory_limit is None:
+        print("\nNo GPU memory limiter used.\n")
+        return
+
+    print("\nAttempting to limit GPU memory to {}.\n".format(memory_limit))
+    gpus = tf.config.list_physical_devices("GPU")
+    for gpu in tf.config.list_physical_devices("GPU"):
+        config = tf.config.experimental.VirtualDeviceConfiguration(
+                      memory_limit=memory_limit)
+        tf.config.experimental.set_virtual_device_configuration(gpu, [config])
+        print("Limiting memory of {} to {}.".format(gpu.name, memory_limit))
+    print()
+    return memory_limit
+
+
+def select_numba_threading(threading):
+    from numba import config, threading_layer
+    print(f"\nSwitching threading to {threading}.\n")
+    config.THREADING_LAYER = threading
+    return threading_layer


### PR DESCRIPTION
Adds script that benchmarks performance of various qibo backends (qibojit, qibotf, etc.) for circuit simulation. The scripts are based on the benchmark from the qibo repository which builds the circuit using the qibo API.

TODO:
- [ ] Expand the list of available circuits (for example based on table 1 of the [HyQuas paper](https://dl.acm.org/doi/pdf/10.1145/3447818.3460357))
- [ ] Include a README with documentation on:
    * how to run benchmarks
    * how to read/plot the log files
    * how to install each qibo backend
- [ ] Add bash scripts that execute the benchmarks on CPU and GPU (perhaps customized for specific machines).
- [ ] Optional: Change `print` messages to a custom logger (similar to what we have in qibo).
- [ ] Optional: Add a benchmark that calls the custom operators of qibotf/qibojit directly, without building qibo circuits. This will give an estimate of qibo's overhead.

I will edit this post with a complete list of the circuits we would like in order to track progress.