### PR TITLE
fixing two-qubit-gate crash

### DIFF
--- a/benchmarks/circuits.py
+++ b/benchmarks/circuits.py
@@ -41,9 +41,9 @@ class TwoQubitGate(OneQubitGate):
     def __iter__(self):
         for _ in range(self.nlayers):
             for i in range(0, self.nqubits - 1, 2):
-                yield self.gate(i, i + 1, **self.params)
+                yield self.gate(i, i + 1, **self.angles)
             for i in range(1, self.nqubits - 1, 2):
-                yield self.gate(i, i + 1, **self.params)
+                yield self.gate(i, i + 1, **self.angles)
 
 
 class QFT(BaseCircuit):


### PR DESCRIPTION
Fixes "AttributeError: 'TwoQubitGate' object has no attribute 'params'" crash.
@stavros11 could you please confirm my interpretation is correct?