### PR TITLE
Set `max_largest_intermediate` for hybridq

### DIFF
--- a/benchmarks/libraries/hybridq.py
+++ b/benchmarks/libraries/hybridq.py
@@ -100,7 +100,8 @@ class HybridQ(abstract.ParserBackend):
                                initial_state=initial_state,
                                complex_type=self.complex_type,
                                simplify=self.simplify,
-                               compress=self.max_qubits)
+                               compress=self.max_qubits,
+                               max_largest_intermediate=2**40)
         return final_state.ravel()
 
     def transpose_state(self, x):
@@ -136,5 +137,6 @@ class HybridQGPU(HybridQ):
                                initial_state=initial_state,
                                complex_type=self.complex_type,
                                simplify=self.simplify,
-                               compress=self.max_qubits)
+                               compress=self.max_qubits,
+                               max_largest_intermediate=2**40)
         return final_state.ravel()


### PR DESCRIPTION
Fixes #30. Apparently there is a [`max_largest_intermediate`](https://github.com/nasa/hybridq/blob/cb49efee8be9aa37b99bba68a9d547500424d231/hybridq/circuit/simulation/simulation.py#L185) option in hybridq's `simulate` which is relevant for their tensor network simulator but, at least according to the documentation, is only used to raise an error for the state vector simulator. Here I hardcode a very high value (40 qubits) in this parameter so that we never get the error. I tried on qibomachine CPU and it works now, previously I was getting the same error. @mlazzarin can you also try with your examples?

By the way, I have not checked in detail where this value is used in their code, so I am not sure if setting it to a very high number has any effect in performance when simulating smaller circuits.