### PR TITLE
Change version of TensorFlow in CI

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -21,7 +21,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install pytest
         pip install qiskit openfermion qulacs hybridq
-        pip install tensorflow==2.5.1
+        pip install tensorflow==2.7.0
         pip install tensorflow_quantum
         pip install projectq
         pip install qsimcirq


### PR DESCRIPTION
The latest release of TensorFlow Quantum requires TensorFlow v2.7.0
https://github.com/tensorflow/quantum/releases/tag/v0.6.0
I notice this because the CI in https://github.com/qiboteam/qibojit-benchmarks/pull/26 was failing.