### PR TITLE
Fix qiskit-gpu when precision is set

### DIFF
--- a/benchmarks/libraries/qiskit.py
+++ b/benchmarks/libraries/qiskit.py
@@ -54,11 +54,11 @@ class QiskitGpu(Qiskit):
         from qiskit.providers.aer import StatevectorSimulator
         super().__init__(max_qubits)
         self.name = "qiskit-gpu"
-        self.options = dict(
+        self.sim_options = dict(
                 device="GPU",
                 fusion_enable=self.max_qubits > 0,
                 fusion_max_qubit=self.max_qubits,
                 fusion_threshold=int(fusion_threshold),
                 precision="double"
             )
-        self.simulator = StatevectorSimulator(**self.options)
+        self.simulator = StatevectorSimulator(**self.sim_options)


### PR DESCRIPTION
Fixes the issue we have with qiskit-gpu for which performance appears similar to qiskit-cpu in the library comparison bar plots. Apparently our qiskit-gpu falls back to cpu when the precision option is used in the compare.py script, due to a typo in the simulator option definition.