### PR TITLE
Disable minor ticks in time evolution plot

### DIFF
--- a/plots/evolution.py
+++ b/plots/evolution.py
@@ -47,7 +47,7 @@ def plot_dense(data, quantity, nqubits, fontsize=30, legend=True, save=False):
         plt.show()
 
 
-def plot_trotter(data, quantity, nqubits, fontsize=30, legend=False, save=False):
+def plot_trotter(data, quantity, nqubits, fontsize=30, yticks=None, legend=False, save=False):
     matplotlib.rcParams["font.size"] = fontsize
     
     cpu_cp = sns.color_palette("Oranges", 4)
@@ -92,7 +92,9 @@ def plot_trotter(data, quantity, nqubits, fontsize=30, legend=False, save=False)
 
     if legend:
         plt.legend(fontsize="small")
-    
+    if yticks is not None:
+        plt.minorticks_off()
+        plt.yticks(yticks)
     if save:
         plt.savefig(f"evolution_trotter_{nqubits}qubits_{quantity}.pdf", bbox_inches="tight")
     else:

--- a/plots/paper-plots.ipynb
+++ b/plots/paper-plots.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "97f43ed0",
    "metadata": {},
    "outputs": [],
@@ -308,8 +308,8 @@
     "from evolution import plot_trotter\n",
     "\n",
     "data = load_evolution_data(\"data/evolution.dat\")\n",
-    "plot_trotter(data, \"total_dry_time\", 10, save=save)\n",
-    "plot_trotter(data, \"total_dry_time\", 20, legend=True, save=save)"
+    "plot_trotter(data, \"total_dry_time\", 10, yticks=[1, 10], legend=True, save=save)\n",
+    "plot_trotter(data, \"total_dry_time\", 20, yticks=[1, 10, 100], legend=False, save=save)"
    ]
   }
  ],


### PR DESCRIPTION
Disables the minor ticks of the time evolution scaling semilogy plot, so that the scale of plots for 10 and 20 qubits is the same.