### PR TITLE
recreate and delete circuit in every run to make sure the GPU memory is freed

### DIFF
--- a/benchmarks/scripts.py
+++ b/benchmarks/scripts.py
@@ -56,9 +56,17 @@ def circuit_benchmark(nqubits, backend, circuit_name, circuit_options=None,
     logs.log(dry_run_transfer_time=time.time() - start_time)
     dtype = str(result.state().dtype)
     del(result)
+    del(circuit)
 
-    simulation_times, transfer_times = [], []
+    creation_times, simulation_times, transfer_times = [], [], []
     for _ in range(nreps):
+        start_time = time.time()
+        circuit = qibo.models.Circuit(nqubits)
+        circuit.add(gates)
+        if nshots is not None:
+            # add measurement gates
+            circuit.add(qibo.gates.M(*range(nqubits)))
+        creation_times.append(time.time() - start_time)
         start_time = time.time()
         result = circuit(nshots=nshots)
         simulation_times.append(time.time() - start_time)
@@ -67,9 +75,12 @@ def circuit_benchmark(nqubits, backend, circuit_name, circuit_options=None,
             result = result.numpy()
         transfer_times.append(time.time() - start_time)
         del(result)
+        del(circuit)
 
-    logs.log(dtype=dtype, simulation_times=simulation_times,
+    logs.log(dtype=dtype, creation_times=creation_times,
+             simulation_times=simulation_times,
              transfer_times=transfer_times)
+    logs.average("creation_times")
     logs.average("simulation_times")
     logs.average("transfer_times")
 

--- a/benchmarks/scripts.py
+++ b/benchmarks/scripts.py
@@ -55,8 +55,8 @@ def circuit_benchmark(nqubits, backend, circuit_name, circuit_options=None,
         result = result.numpy()
     logs.log(dry_run_transfer_time=time.time() - start_time)
     dtype = str(result.state().dtype)
-    del(result)
-    del(circuit)
+    del result
+    del circuit
 
     creation_times, simulation_times, transfer_times = [], [], []
     for _ in range(nreps):
@@ -74,8 +74,8 @@ def circuit_benchmark(nqubits, backend, circuit_name, circuit_options=None,
         if transfer:
             result = result.numpy()
         transfer_times.append(time.time() - start_time)
-        del(result)
-        del(circuit)
+        del result
+        del circuit
 
     logs.log(dtype=dtype, creation_times=creation_times,
              simulation_times=simulation_times,
@@ -131,14 +131,14 @@ def library_benchmark(nqubits, library, circuit_name, circuit_options=None,
     result = backend(circuit)
     logs.log(dry_run_time=time.time() - start_time)
     dtype = str(result.dtype)
-    del(result)
+    del result
 
     simulation_times = []
     for _ in range(nreps):
         start_time = time.time()
         result = backend(circuit)
         simulation_times.append(time.time() - start_time)
-        del(result)
+        del result
 
     logs.log(dtype=dtype, simulation_times=simulation_times)
     logs.average("simulation_times")
@@ -180,7 +180,7 @@ def evolution_benchmark(nqubits, dt, solver, backend, platform=None,
     result = evolution(final_time=1.0)
     logs.log(dry_run_time=time.time() - start_time)
     dtype = str(result.dtype)
-    del(result)
+    del result
 
     simulation_times = []
     for _ in range(nreps):


### PR DESCRIPTION
when running `circuit_benchmarks` that use more than half of the GPU memory, the `dry_run` runs fine but then the next run fails with, for instance (for a 32 qubit double precision circuit, 64GB, on a GPU with 96GB of memory)

`cupy.cuda.memory.OutOfMemoryError: Out of memory allocating 68,719,476,736 bytes (allocated so far: 68,719,476,736 bytes)`

these changes work around the issue for me by always destroying the circuit, which frees the GPU memory, and always recreating it (but I suppose an alternative would be to avoid recreating the circuits by e.g. adding a method to the circuit class that clears the state, or making its constructor overwrite any existing state?)

cc @scarrazza 